### PR TITLE
Swap querystring for body-parser

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 const express = require("express");
 const { mf2 } = require("microformats-parser");
 const undici = require("undici");
-const querystring = require("querystring");
+const bodyParser = require("body-parser");
 const pkg = require("./package.json");
 const app = express();
 const port = process.env.PORT || 9000;
@@ -44,9 +44,8 @@ app.get("/", async (req, res) => {
     });
   }
 });
-app.post("/", (req, res) => {
-  const qsBody = querystring.parse(req.body);
-  htmlToMf2(qsBody.url, qsBody.html, res);
+app.post("/", bodyParser.urlencoded({ extended: false }), (req, res) => {
+  htmlToMf2(req.body.url, req.body.html, res);
 });
 
 app.listen(port, () => {

--- a/index.js
+++ b/index.js
@@ -1,7 +1,6 @@
 const express = require("express");
 const { mf2 } = require("microformats-parser");
 const undici = require("undici");
-const bodyParser = require("body-parser");
 const pkg = require("./package.json");
 const app = express();
 const port = process.env.PORT || 9000;
@@ -44,7 +43,7 @@ app.get("/", async (req, res) => {
     });
   }
 });
-app.post("/", bodyParser.urlencoded({ extended: false }), (req, res) => {
+app.post("/", express.urlencoded({ extended: false }), (req, res) => {
   htmlToMf2(req.body.url, req.body.html, res);
 });
 

--- a/package.json
+++ b/package.json
@@ -11,10 +11,10 @@
   },
   "dependencies": {
     "@yarnpkg/lockfile": "^1.1.0",
+    "body-parser": "^1.20.1",
     "ejs": "^3.1.8",
     "express": "^4.18.1",
     "microformats-parser": "^1.4.1",
-    "querystring": "^0.2.1",
     "undici": "^5.6.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
   },
   "dependencies": {
     "@yarnpkg/lockfile": "^1.1.0",
-    "body-parser": "^1.20.1",
     "ejs": "^3.1.8",
     "express": "^4.18.1",
     "microformats-parser": "^1.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -55,6 +55,24 @@ body-parser@1.20.0:
     type-is "~1.6.18"
     unpipe "1.0.0"
 
+body-parser@^1.20.1:
+  version "1.20.1"
+  resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.20.1.tgz#b1812a8912c195cd371a3ee5e66faa2338a5c668"
+  integrity sha512-jWi7abTbYwajOytWCQc37VulmWiRae5RyTpaCyDcS5/lMdtwSz5lOpDE67srw/HYe35f1z3fDQw+3txg7gNtWw==
+  dependencies:
+    bytes "3.1.2"
+    content-type "~1.0.4"
+    debug "2.6.9"
+    depd "2.0.0"
+    destroy "1.2.0"
+    http-errors "2.0.0"
+    iconv-lite "0.4.24"
+    on-finished "2.4.1"
+    qs "6.11.0"
+    raw-body "2.5.1"
+    type-is "~1.6.18"
+    unpipe "1.0.0"
+
 brace-expansion@^1.1.7:
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
@@ -420,10 +438,12 @@ qs@6.10.3:
   dependencies:
     side-channel "^1.0.4"
 
-querystring@^0.2.1:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.1.tgz#40d77615bb09d16902a85c3e38aa8b5ed761c2dd"
-  integrity sha512-wkvS7mL/JMugcup3/rMitHmd9ecIGd2lhFhK9N3UUQ450h66d1r3Y9nvXzQAW1Lq+wyx61k/1pfKS5KuKiyEbg==
+qs@6.11.0:
+  version "6.11.0"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.11.0.tgz#fd0d963446f7a65e1367e01abd85429453f0c37a"
+  integrity sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==
+  dependencies:
+    side-channel "^1.0.4"
 
 range-parser@~1.2.1:
   version "1.2.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -55,24 +55,6 @@ body-parser@1.20.0:
     type-is "~1.6.18"
     unpipe "1.0.0"
 
-body-parser@^1.20.1:
-  version "1.20.1"
-  resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.20.1.tgz#b1812a8912c195cd371a3ee5e66faa2338a5c668"
-  integrity sha512-jWi7abTbYwajOytWCQc37VulmWiRae5RyTpaCyDcS5/lMdtwSz5lOpDE67srw/HYe35f1z3fDQw+3txg7gNtWw==
-  dependencies:
-    bytes "3.1.2"
-    content-type "~1.0.4"
-    debug "2.6.9"
-    depd "2.0.0"
-    destroy "1.2.0"
-    http-errors "2.0.0"
-    iconv-lite "0.4.24"
-    on-finished "2.4.1"
-    qs "6.11.0"
-    raw-body "2.5.1"
-    type-is "~1.6.18"
-    unpipe "1.0.0"
-
 brace-expansion@^1.1.7:
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
@@ -435,13 +417,6 @@ qs@6.10.3:
   version "6.10.3"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.10.3.tgz#d6cde1b2ffca87b5aa57889816c5f81535e22e8e"
   integrity sha512-wr7M2E0OFRfIfJZjKGieI8lBKb7fRCH4Fv5KNPEs7gJ8jadvotdsS08PzOKR7opXhZ/Xkjtt3WF9g38drmyRqQ==
-  dependencies:
-    side-channel "^1.0.4"
-
-qs@6.11.0:
-  version "6.11.0"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.11.0.tgz#fd0d963446f7a65e1367e01abd85429453f0c37a"
-  integrity sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==
   dependencies:
     side-channel "^1.0.4"
 


### PR DESCRIPTION
Fixes #2.

This aligns us more with [Express’ own documentation](http://expressjs.com/en/4x/api.html#req.body) by using their bundled middleware to parse the form.