### PR TITLE
Add bookmarklet to page

### DIFF
--- a/views/index.html.ejs
+++ b/views/index.html.ejs
@@ -98,6 +98,15 @@
         <button type="submit" class="btn btn-lg btn-success">Parse</button>
       </form>
 
+      <hr>
+
+      <p>
+        Drag this link to your bookmarks toolbar to parse a page with one click!<br>
+      </p>
+      <a class="btn btn-primary btn-sm" href="javascript:(function(){document.location.href='https://node.microformats.io/?url='+encodeURIComponent(document.location.href);}())">mf2 parser</a>
+      
+      <hr>
+
       <footer class="my-5">
         <ul>
           <li><a href="https://microformats.io">About Microformats</a></li>


### PR DESCRIPTION
I saw that https://php.microformats.io/ had a handy bookmarklet and thought that might be useful to add to the node site as I often am specifically debugging the node parsing.

![Screenshot of Microformats Parser (Node) page with section containing an 'mf2 parser' button and an explainer to 'Drag this link to your bookmarks toolbar to parse a page with one click!'](https://github.com/microformats/microformats-parser-website-node/assets/11273838/0021223a-728f-45a8-97b4-48de9ee81a19)
